### PR TITLE
Fixed markdown format errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,10 +42,10 @@ You can always open new issue in this repository with [Issues] tab!
 _Variables/Functions_ use `snake_case`, and for public versions prepend the header it is defined in (for types (excluding structures) `_t` at the end: `token_t`). <br/>
 _Structs/Unions/Enums_ use `PascalCase`
 _Defined Constants_ (`#define`) should have `SCREAMING_SNAKE_CASE`. <br/>
-_Other Constants_ postpend `_k` to the name. <br\>
+_Other Constants_ should have prefix `k`. <br/>
 3. **Includes** are located at the start, _standard library headers_ must be separated from _user header files_.
 4. **Repeating** code suggested to be in separated function.
 5. **No Magic Numbers**. If you need to use that number, declare a constant with it.
 6. **Comments** should be minimal and helpful. Please do not leave a comment saying \"_foo_ gets set to _7_\" <br/>
-Always leave necessary documentation for provided API and changes.\
+Always leave necessary documentation for provided API and changes.
 7. **The code blocks** should not be "glued together", they should be separated according to their logical meaning. AKA put line breaks after loops, group variables, etc.


### PR DESCRIPTION
Fixed mistakes like: random backslashes `\` and new line HTML tag