### PR TITLE
Fix Seg Fault Issue Caused By Pull Request #13

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -27,6 +27,7 @@ void parse_and_print(char* input) {
 
   print_sexp(sexp);
   printf("\n");
+}
 
 char* read_file(const char* filename) {
     FILE* f = fopen(filename, "rb");
@@ -48,8 +49,9 @@ void print_usage(char* name) {
   fprintf(stderr,
           "Usage: %s [options] <code>\n\n"
           "Options:\n"
-          "-t   Print tokens.\n"
-          "-p   Print AST.\n",
+          "-f <file> Read code from file\n"
+          "-t        Print tokens.\n"
+          "-p        Print AST.\n",
           name);
 }
 
@@ -58,9 +60,13 @@ int main(int argc, char** argv) {
   bool parse = false;
   bool tokenize = false;
   bool execute = true;
+  char* filename = NULL;
 
-  while ((opt = getopt(argc, argv, "tp")) != -1) {
+  while ((opt = getopt(argc, argv, "f:tp")) != -1) {
     switch (opt) {
+      case 'f':
+        filename = optarg;
+        break;
       case 't':
         tokenize = true;
         execute = false;
@@ -76,29 +82,26 @@ int main(int argc, char** argv) {
     }
   }
 
-  char* input_from_file = NULL;
-  input_from_file = read_file(argv[optind]);
-
   char* input = NULL;
 
-  if (input_from_file) {
-    input = input_from_file;
-  } else {
+  if (!filename) {
     input = argv[optind];
     if (!input) {
       print_usage(argv[0]);
       return 1;
     }
+  } else {
+    input = read_file(filename);
   }
 
   remove_outer_quotes(input);
 
-  token_streamer streamer = token_streamer_init(input);
+  TokenStreamer streamer = token_streamer_init(input);
   if (execute) {
     interpreter_t* interp = init_interpreter();
 
     while (1) {
-      token_t* token = token_streamer_next(&streamer);
+      Token* token = token_streamer_next(&streamer);
       if (token->type == TOKEN_EOF) {
         break;
       }
@@ -119,7 +122,7 @@ int main(int argc, char** argv) {
   }
 
   if (tokenize) {
-    token_streamer streamer = token_streamer_init(input);
+    TokenStreamer streamer = token_streamer_init(input);
 
     Token* token = token_streamer_next(&streamer);
 
@@ -136,7 +139,7 @@ int main(int argc, char** argv) {
     streamer = token_streamer_init(input);
 
     while (1) {
-      token_t* token = token_streamer_next(&streamer);
+      Token* token = token_streamer_next(&streamer);
       if (token->type == TOKEN_EOF) {
         break;
       }


### PR DESCRIPTION
The seg fault was caused by passing a NULL FILE* pointer.

```
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x68) 
frame #0: 0x0000000180f86c64 libsystem_c.dylibflockfile + 28 
libsystem_c.dylibflockfile: -> 
  0x180f86c64 <+28>: ldr x8, [x19, #0x68] 
  0x180f86c68 <+32>: add x0, x8, #0x8 
  0x180f86c6c <+36>: bl 0x180ff1298 ; symbol stub for: pthread_mutex_lock 
  0x180f86c70 <+40>: bl 0x180ff0618 ; symbol stub for: __error Target 0: (pnd) stopped.
```

This was an oversight on my part when setting up the ability to pass pnd programs stored in files. It should be fixed by adding a -f <file> option.

New Usage:

```
./build/pnd -f example.pnd
```